### PR TITLE
Update manual pre-release to alpha.4

### DIFF
--- a/cue-prerelease.rb
+++ b/cue-prerelease.rb
@@ -8,16 +8,16 @@ class CuePrerelease < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.3/cue_v0.13.0-alpha.3_darwin_amd64.tar.gz"
-      sha256 "96b3c3e1513044a6b9ed9b73edfd40be42d7f9a2a3deef505874f0aaac6d564c"
+      url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.4/cue_v0.13.0-alpha.4_darwin_amd64.tar.gz"
+      sha256 "81d2deb4c72de25768b8dc054234770b8a5451216ee2e3d750c25598d843ccf0"
 
       def install
         bin.install "cue"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.3/cue_v0.13.0-alpha.3_darwin_arm64.tar.gz"
-      sha256 "3c1e72eab55355108663b1327af6ed7f323e048690a6e8a99f4e8efdf2049279"
+      url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.4/cue_v0.13.0-alpha.4_darwin_arm64.tar.gz"
+      sha256 "b1219ec5866c204d210f79032c5fb126b600ae2b5664d50ff1acef2676f72254"
 
       def install
         bin.install "cue"
@@ -28,8 +28,8 @@ class CuePrerelease < Formula
   on_linux do
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.3/cue_v0.13.0-alpha.3_linux_amd64.tar.gz"
-        sha256 "53c909752331dc99074eb881b65e1d99176099d038a3791a7b275be28c65deb6"
+        url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.4/cue_v0.13.0-alpha.4_linux_amd64.tar.gz"
+        sha256 "4289c1399f584f3b262787b3aeed40ff1cef1184073347737e39b8a2cd94e516"
 
         def install
           bin.install "cue"
@@ -38,8 +38,8 @@ class CuePrerelease < Formula
     end
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.3/cue_v0.13.0-alpha.3_linux_arm64.tar.gz"
-        sha256 "55b6aee99b9f5d3233c3afb86ead30e392285d92b1c5f639ce02cb7f3c9ff919"
+        url "https://github.com/cue-lang/cue/releases/download/v0.13.0-alpha.4/cue_v0.13.0-alpha.4_linux_arm64.tar.gz"
+        sha256 "28a884f334be907714540d879df7090ea2b00b8db9716a0d0ffcba2be01c3c68"
 
         def install
           bin.install "cue"


### PR DESCRIPTION
This was missed when alpha.4 was released. cue-lang/cue#3866 would have removed the need for this manual update.